### PR TITLE
feat(mcp): always show remediation guidance in MCP instructions

### DIFF
--- a/rbac/management/mcp_views.py
+++ b/rbac/management/mcp_views.py
@@ -4912,33 +4912,40 @@ _MCP_INSTRUCTIONS_HONEST_CAVEATS = (
     "accurate guidance."
 )
 
-_MCP_INSTRUCTIONS_SUGGESTION_LAYER = (
-    "\n\n## Suggestion Layer\n\n"
-    "After completing a readonly analysis, present the user with numbered write-action "
-    "options they can select from. Format suggestions as:\n\n"
-    '"Want me to: (1) <action>, or (2) <action>, or (3) <action>? '
-    "Reply 1, 2, or 3 -- or 'no'.\"\n\n"
-    "Guidelines:\n"
-    "- Always include a 'do nothing' or 'audit first' option when the action is irreversible.\n"
-    "- For permission gaps: offer to add the user to an existing group with the right role, "
-    "create a narrow custom role, or add the role to the user's current group.\n"
-    "- For group dissolution: offer immediate deletion, a transition group for stranded members, "
+_MCP_INSTRUCTIONS_REMEDIATION = (
+    "\n\n## Remediation Guidance\n\n"
+    "After completing a readonly analysis that reveals a problem (permission gap, stale membership, "
+    "unauthorized change, etc.), always suggest concrete next steps the user or an admin can take "
+    "to resolve it. Present remediation as numbered options:\n\n"
+    '"To fix this you could: (1) <action>, (2) <action>, or (3) <action>."\n\n'
+    "Scenario-specific guidance:\n"
+    "- **Permission gaps**: suggest (a) adding the user to an existing group that already has "
+    "the right role, (b) creating a narrow custom role with just the needed permissions, or "
+    "(c) adding the missing role to the user's current group.\n"
+    "- **Group dissolution**: suggest immediate deletion, a transition group for stranded members, "
     "or partial cleanup.\n"
-    "- For audit investigations: offer to remove unauthorized changes, revoke the actor's access, "
+    "- **Audit investigations**: suggest removing unauthorized changes, revoking the actor's access, "
     "or both.\n"
-    "- For offboarding: offer to remove the user from groups, generate a report, or both.\n"
-    "- For cross-account access: offer to update or cancel requests, or generate a briefing report.\n"
-    "- For review-only scenarios (e.g., summarizing recent changes): do NOT offer write actions. "
-    "Present the summary and let the user ask follow-up questions.\n"
-    "- NEVER execute a write tool without the user explicitly selecting an option."
+    "- **Offboarding**: suggest removing the user from groups, generating a report, or both.\n"
+    "- **Cross-account access**: suggest updating or cancelling requests, or generating a briefing report.\n"
+    "- **Review-only scenarios** (e.g., summarizing recent changes): do NOT suggest write actions. "
+    "Present the summary and let the user ask follow-up questions.\n\n"
+    "Always include a 'do nothing / audit first' option when the action is irreversible."
+)
+
+_MCP_INSTRUCTIONS_WRITE_ACTIONS = (
+    "\n\n## Write Actions\n\n"
+    "Write tools are enabled. When presenting remediation options, offer to execute them directly. "
+    "Format as: \"Want me to do this now? Reply 1, 2, or 3 -- or 'no'.\"\n\n"
+    "NEVER execute a write tool without the user explicitly selecting an option."
 )
 
 
 def _build_mcp_instructions() -> str:
     """Build MCP server instructions based on current feature flags."""
-    parts = [_MCP_INSTRUCTIONS_BASE, _MCP_INSTRUCTIONS_HONEST_CAVEATS]
+    parts = [_MCP_INSTRUCTIONS_BASE, _MCP_INSTRUCTIONS_HONEST_CAVEATS, _MCP_INSTRUCTIONS_REMEDIATION]
     if _is_write_enabled():
-        parts.append(_MCP_INSTRUCTIONS_SUGGESTION_LAYER)
+        parts.append(_MCP_INSTRUCTIONS_WRITE_ACTIONS)
     return "".join(parts)
 
 

--- a/tests/management/test_mcp_views.py
+++ b/tests/management/test_mcp_views.py
@@ -132,26 +132,35 @@ class MCPViewTests(MCPToolTestMixin, IdentityRequest):
         self.assertIn("instructions", result)
         self.assertIn("RBAC", result["instructions"])
 
-    @override_settings(MCP_WRITE_ENABLED=True)
-    def test_initialize_instructions_include_suggestion_layer_when_writes_enabled(self):
-        """Positive: instructions include suggestion layer guidance when write mode is on."""
+    def test_initialize_instructions_always_include_remediation_guidance(self):
+        """Positive: instructions always include remediation guidance regardless of write mode."""
         body = {"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}}
         response = self.client.post(self.url, data=json.dumps(body), content_type="application/json", **self.headers)
 
         instructions = response.json()["result"]["instructions"]
-        self.assertIn("Suggestion Layer", instructions)
-        self.assertIn("numbered write-action", instructions)
+        self.assertIn("Remediation Guidance", instructions)
+        self.assertIn("Permission gaps", instructions)
+        self.assertIn("numbered options", instructions)
+
+    @override_settings(MCP_WRITE_ENABLED=True)
+    def test_initialize_instructions_include_write_actions_when_writes_enabled(self):
+        """Positive: instructions include write action prompt when write mode is on."""
+        body = {"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}}
+        response = self.client.post(self.url, data=json.dumps(body), content_type="application/json", **self.headers)
+
+        instructions = response.json()["result"]["instructions"]
+        self.assertIn("Write Actions", instructions)
         self.assertIn("NEVER execute a write tool", instructions)
 
     @override_settings(MCP_WRITE_ENABLED=False)
-    def test_initialize_instructions_omit_suggestion_layer_when_writes_disabled(self):
-        """Negative: instructions omit suggestion layer when write mode is off."""
+    def test_initialize_instructions_omit_write_actions_when_writes_disabled(self):
+        """Negative: instructions omit write action prompt when write mode is off."""
         body = {"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}}
         response = self.client.post(self.url, data=json.dumps(body), content_type="application/json", **self.headers)
 
         instructions = response.json()["result"]["instructions"]
-        self.assertNotIn("Suggestion Layer", instructions)
-        self.assertNotIn("write-action", instructions)
+        self.assertNotIn("Write Actions", instructions)
+        self.assertIn("Remediation Guidance", instructions)
 
     def test_initialize_instructions_include_honest_caveats(self):
         """Positive: instructions always include cross-cutting honest caveats."""


### PR DESCRIPTION
## Summary
- Split the MCP suggestion layer into two independent instruction blocks:
  - **`_MCP_INSTRUCTIONS_REMEDIATION`** — always included, tells the LLM to suggest concrete fix steps after diagnosing problems (permission gaps, stale memberships, unauthorized changes, etc.)
  - **`_MCP_INSTRUCTIONS_WRITE_ACTIONS`** — only included when `MCP_WRITE_ENABLED=True`, adds the "Want me to execute this?" prompt
- Previously, the entire suggestion layer was gated behind `MCP_WRITE_ENABLED`, so read-only deployments gave no actionable remediation guidance
- Updated 3 existing tests to match the new instruction structure (remediation always present, write actions conditionally present)

## Test plan
- [x] `test_initialize_instructions_always_include_remediation_guidance` — verifies remediation guidance appears without write mode
- [x] `test_initialize_instructions_include_write_actions_when_writes_enabled` — verifies write action prompt appears when writes on
- [x] `test_initialize_instructions_omit_write_actions_when_writes_disabled` — verifies write action prompt is absent when writes off, but remediation still present
- [x] Existing honest caveats and base instruction tests still pass
- [x] Pre-commit hooks (flake8, black, trailing whitespace) pass