### PR TITLE
fix(dr): check TenantMapping for bootstrap virtual group/role_binding resources

### DIFF
--- a/rbac/management/disaster_recovery/resource_checker.py
+++ b/rbac/management/disaster_recovery/resource_checker.py
@@ -4,12 +4,13 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from django.db.models import Model
+from django.db.models import Model, Q
 from management.group.model import Group
 from management.principal.model import Principal
 from management.relation_replicator.types import RelationTuple
 from management.role.model import Role
 from management.role_binding.model import RoleBinding
+from management.tenant_mapping.model import TenantMapping
 from management.workspace.model import Workspace
 
 from api.models import Tenant
@@ -40,6 +41,30 @@ RESOURCE_TYPE_REGISTRY: dict[str, ResourceTypeConfig] = {
     "tenant": ResourceTypeConfig(model=Tenant, id_field="org_id", id_transform=_strip_domain_prefix),
 }
 
+_TENANT_MAPPING_GROUP_FIELDS = ("default_group_uuid", "default_admin_group_uuid")
+
+_TENANT_MAPPING_ROLE_BINDING_FIELDS = (
+    "default_role_binding_uuid",
+    "default_admin_role_binding_uuid",
+    "root_scope_default_role_binding_uuid",
+    "root_scope_default_admin_role_binding_uuid",
+    "tenant_scope_default_role_binding_uuid",
+    "tenant_scope_default_admin_role_binding_uuid",
+)
+
+
+def _find_in_tenant_mapping(uuids: set[str], fields: tuple[str, ...]) -> set[str]:
+    """Find UUIDs that exist in TenantMapping across the given fields."""
+    q = Q()
+    for field in fields:
+        q |= Q(**{f"{field}__in": uuids})
+
+    found: set[str] = set()
+    for row in TenantMapping.objects.filter(q).values_list(*fields):
+        found.update(str(v) for v in row if v is not None)
+
+    return found & uuids
+
 
 def check_resources_exist(tuples: list[RelationTuple]) -> dict[tuple[str, str], bool]:
     """Check which resources referenced by tuples exist in the RBAC database.
@@ -47,6 +72,10 @@ def check_resources_exist(tuples: list[RelationTuple]) -> dict[tuple[str, str], 
     Returns a dict mapping (resource_type_name, resource_id) -> exists.
     Groups queries by resource type for efficiency (one query per type).
     Unknown types return True (safe default = skip corrective action).
+
+    For group and role_binding types, also checks TenantMapping because
+    bootstrap_tenant creates relation tuples referencing UUIDs stored in
+    TenantMapping without creating actual Group/RoleBinding model instances.
     """
     ids_by_type: dict[str, set[str]] = {}
 
@@ -80,4 +109,25 @@ def check_resources_exist(tuples: list[RelationTuple]) -> dict[tuple[str, str], 
         for raw_id, lookup_id in id_mapping.items():
             result[(type_name, raw_id)] = str(lookup_id) in existing_ids
 
+    _enrich_from_tenant_mapping(result)
+
     return result
+
+
+def _enrich_from_tenant_mapping(result: dict[tuple[str, str], bool]) -> None:
+    """Check TenantMapping for group/role_binding UUIDs not found in their primary models."""
+    missing_groups = {raw_id for (type_name, raw_id), exists in result.items() if type_name == "group" and not exists}
+    if missing_groups:
+        found = _find_in_tenant_mapping(missing_groups, _TENANT_MAPPING_GROUP_FIELDS)
+        for raw_id in found:
+            result[("group", raw_id)] = True
+            logger.debug("Group '%s' found in TenantMapping (bootstrap virtual resource)", raw_id)
+
+    missing_rbs = {
+        raw_id for (type_name, raw_id), exists in result.items() if type_name == "role_binding" and not exists
+    }
+    if missing_rbs:
+        found = _find_in_tenant_mapping(missing_rbs, _TENANT_MAPPING_ROLE_BINDING_FIELDS)
+        for raw_id in found:
+            result[("role_binding", raw_id)] = True
+            logger.debug("RoleBinding '%s' found in TenantMapping (bootstrap virtual resource)", raw_id)

--- a/tests/management/disaster_recovery/test_resource_checker.py
+++ b/tests/management/disaster_recovery/test_resource_checker.py
@@ -19,6 +19,7 @@ from management.relation_replicator.types import (
     SubjectReference,
 )
 from management.role.model import Role
+from management.tenant_mapping.model import TenantMapping
 from management.workspace.model import Workspace
 
 
@@ -174,3 +175,121 @@ class ResourceCheckerTest(TestCase):
     def test_registry_covers_expected_types(self):
         expected = {"workspace", "role", "group", "principal", "role_binding", "tenant"}
         self.assertEqual(set(RESOURCE_TYPE_REGISTRY.keys()), expected)
+
+
+class TenantMappingFallbackTest(TestCase):
+    """Test that group/role_binding UUIDs from TenantMapping are found even without model instances."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.tenant = Tenant.objects.create(
+            tenant_name="test-mapping-tenant",
+            account_id="test-mapping-account",
+            org_id="test-mapping-org",
+            ready=True,
+        )
+        cls.root_ws = Workspace.objects.create(
+            name=Workspace.SpecialNames.ROOT,
+            type=Workspace.Types.ROOT,
+            tenant=cls.tenant,
+        )
+        cls.default_ws = Workspace.objects.create(
+            name=Workspace.SpecialNames.DEFAULT,
+            type=Workspace.Types.DEFAULT,
+            tenant=cls.tenant,
+            parent=cls.root_ws,
+        )
+        cls.mapping = TenantMapping.objects.create(tenant=cls.tenant)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mapping.delete()
+        cls.default_ws.delete()
+        cls.root_ws.delete()
+        cls.tenant.delete()
+        super().tearDownClass()
+
+    def test_group_found_via_tenant_mapping_default_group(self):
+        group_uuid = str(self.mapping.default_group_uuid)
+        t = _make_tuple("group", group_uuid)
+        result = check_resources_exist([t])
+        self.assertTrue(result[("group", group_uuid)])
+
+    def test_group_found_via_tenant_mapping_admin_group(self):
+        group_uuid = str(self.mapping.default_admin_group_uuid)
+        t = _make_tuple("group", group_uuid)
+        result = check_resources_exist([t])
+        self.assertTrue(result[("group", group_uuid)])
+
+    def test_role_binding_found_via_tenant_mapping(self):
+        rb_uuid = str(self.mapping.default_role_binding_uuid)
+        t = _make_tuple("role_binding", rb_uuid)
+        result = check_resources_exist([t])
+        self.assertTrue(result[("role_binding", rb_uuid)])
+
+    def test_role_binding_root_scope_found_via_tenant_mapping(self):
+        rb_uuid = str(self.mapping.root_scope_default_role_binding_uuid)
+        t = _make_tuple("role_binding", rb_uuid)
+        result = check_resources_exist([t])
+        self.assertTrue(result[("role_binding", rb_uuid)])
+
+    def test_role_binding_tenant_scope_found_via_tenant_mapping(self):
+        rb_uuid = str(self.mapping.tenant_scope_default_role_binding_uuid)
+        t = _make_tuple("role_binding", rb_uuid)
+        result = check_resources_exist([t])
+        self.assertTrue(result[("role_binding", rb_uuid)])
+
+    def test_role_binding_admin_found_via_tenant_mapping(self):
+        rb_uuid = str(self.mapping.default_admin_role_binding_uuid)
+        t = _make_tuple("role_binding", rb_uuid)
+        result = check_resources_exist([t])
+        self.assertTrue(result[("role_binding", rb_uuid)])
+
+    def test_group_not_in_mapping_still_returns_false(self):
+        fake_uuid = str(uuid4())
+        t = _make_tuple("group", fake_uuid)
+        result = check_resources_exist([t])
+        self.assertFalse(result[("group", fake_uuid)])
+
+    def test_role_binding_not_in_mapping_still_returns_false(self):
+        fake_uuid = str(uuid4())
+        t = _make_tuple("role_binding", fake_uuid)
+        result = check_resources_exist([t])
+        self.assertFalse(result[("role_binding", fake_uuid)])
+
+    def test_mixed_real_and_virtual_resources(self):
+        """Groups that exist as model instances and groups from TenantMapping both return True."""
+        real_group = Group.objects.create(name="Real DR Group", tenant=self.tenant)
+        virtual_group_uuid = str(self.mapping.default_group_uuid)
+        fake_group_uuid = str(uuid4())
+
+        tuples = [
+            _make_tuple("group", str(real_group.uuid)),
+            _make_tuple("group", virtual_group_uuid),
+            _make_tuple("group", fake_group_uuid),
+        ]
+        result = check_resources_exist(tuples)
+
+        self.assertTrue(result[("group", str(real_group.uuid))])
+        self.assertTrue(result[("group", virtual_group_uuid)])
+        self.assertFalse(result[("group", fake_group_uuid)])
+        real_group.delete()
+
+    def test_bootstrap_scenario_all_virtual_resources(self):
+        """Simulate a full bootstrap event: group, role_binding, workspace all checked."""
+        tuples = [
+            _make_tuple("workspace", str(self.root_ws.id)),
+            _make_tuple("group", str(self.mapping.default_group_uuid)),
+            _make_tuple("group", str(self.mapping.default_admin_group_uuid)),
+            _make_tuple("role_binding", str(self.mapping.default_role_binding_uuid)),
+            _make_tuple("role_binding", str(self.mapping.default_admin_role_binding_uuid)),
+            _make_tuple("role_binding", str(self.mapping.root_scope_default_role_binding_uuid)),
+            _make_tuple("role_binding", str(self.mapping.root_scope_default_admin_role_binding_uuid)),
+            _make_tuple("role_binding", str(self.mapping.tenant_scope_default_role_binding_uuid)),
+            _make_tuple("role_binding", str(self.mapping.tenant_scope_default_admin_role_binding_uuid)),
+        ]
+        result = check_resources_exist(tuples)
+
+        for key, exists in result.items():
+            self.assertTrue(exists, f"Expected {key} to exist")


### PR DESCRIPTION
## Summary

- Fix DR reconciler incorrectly generating REMOVE corrective actions for bootstrap_tenant event tuples
- The `check_resources_exist` function only queried `Group`/`RoleBinding` Django model tables, but `bootstrap_tenant` creates relation tuples referencing UUIDs stored in `TenantMapping` without creating actual model instances — these are "virtual" resources
- Add a `TenantMapping` fallback: after the primary model check, any group or role_binding UUIDs not found are looked up across the 8 `TenantMapping` UUID fields (2 group + 6 role_binding)

## Root Cause

During `bootstrap_tenant`, `TenantMapping` is created with auto-generated UUIDs for default groups (`default_group_uuid`, `default_admin_group_uuid`) and 6 role binding UUIDs. Relation tuples are emitted referencing these UUIDs, but **no actual `Group` or `RoleBinding` Django model objects are created**. The DR reconciler's existence check queried only the model tables, so it reported these resources as non-existent, triggering the truth table path `relations_to_add + not exists → REMOVE` — which would delete valid relations from SpiceDB.

## Test plan

- [x] New `TenantMappingFallbackTest` class with 10 test cases covering:
  - Group found via `default_group_uuid` and `default_admin_group_uuid`
  - Role binding found via all 6 TenantMapping role binding fields
  - UUIDs not in TenantMapping still return `False`
  - Mixed real model instances and virtual TenantMapping resources
  - Full bootstrap scenario with all virtual resources
- [x] All 55 existing DR tests pass
- [x] Pre-commit hooks pass (flake8, black, trailing whitespace)